### PR TITLE
LTSMPS-606 Fixing NPM Organization Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-library/mirador-citation-plugin",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-library/mirador-citation-plugin",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@harvard-library/mirador-citation-plugin",
+    "name": "@harvard-lts/mirador-citation-plugin",
     "version": "0.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@harvard-library/mirador-citation-plugin",
+            "name": "@harvard-lts/mirador-citation-plugin",
             "version": "0.0.2",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@harvard-library/mirador-citation-plugin",
+    "name": "@harvard-lts/mirador-citation-plugin",
     "license": "Apache-2.0",
     "repository": "https://github.com/harvard-lts/mirador-custom-text-search-plugin.git",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,54 +3,53 @@
     "license": "Apache-2.0",
     "repository": "https://github.com/harvard-lts/mirador-custom-text-search-plugin.git",
     "keywords": [
-      "react-component"
+        "react-component"
     ],
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "A Mirador 3 plugin for displaying Harvard-specific citations.",
     "module": "dist/es/index.js",
     "files": [
-      "dist"
+        "dist"
     ],
     "scripts": {
-      "clean": "rm -rf ./dist && rm -rf ./demo/dist",
-      "prebuild": "npm run clean",
-      "prepublishOnly": "npm run build",
-      "build": "run-p build:es",
-      "build:es": "rollup -c",
-      "serve": "webpack serve --mode development --open",
-      "test": "jest",
-      "test:coverage": "jest --coverage",
-      "test:watch": "jest --watch"
+        "clean": "rm -rf ./dist && rm -rf ./demo/dist",
+        "prebuild": "npm run clean",
+        "prepublishOnly": "npm run build",
+        "build": "run-p build:es",
+        "build:es": "rollup -c",
+        "serve": "webpack serve --mode development --open",
+        "test": "jest",
+        "test:coverage": "jest --coverage",
+        "test:watch": "jest --watch"
     },
     "devDependencies": {
-      "@babel/cli": "^7.26.4",
-      "@babel/core": "^7.26.0",
-      "@babel/preset-env": "^7.21.4",
-      "@babel/preset-react": "^7.18.6",
-      "@material-ui/core": "^4.12.4",
-      "@material-ui/icons": "^4.11.2",
-      "@rollup/plugin-babel": "^6.0.3",
-      "@testing-library/jest-dom": "^5.16.5",
-      "@testing-library/react": "^12.0.0",
-      "babel-jest": "^29.7.0",
-      "babel-loader": "^9.1.2",
-      "jest": "^29.7.0",
-      "jest-environment-jsdom": "^29.7.0",
-      "mirador": "^3.4.3",
-      "npm-run-all": "^4.1.5",
-      "rollup": "^3.29.5",
-      "url": "^0.11.0",
-      "webpack": "^5.94.0",
-      "webpack-cli": "^5.1.4",
-      "webpack-dev-server": "^5.2.0",
-      "webpack-node-externals": "^3.0.0",
-      "whatwg-fetch": "^3.6.2"
+        "@babel/cli": "^7.26.4",
+        "@babel/core": "^7.26.0",
+        "@babel/preset-env": "^7.21.4",
+        "@babel/preset-react": "^7.18.6",
+        "@material-ui/core": "^4.12.4",
+        "@material-ui/icons": "^4.11.2",
+        "@rollup/plugin-babel": "^6.0.3",
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^12.0.0",
+        "babel-jest": "^29.7.0",
+        "babel-loader": "^9.1.2",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "mirador": "^3.4.3",
+        "npm-run-all": "^4.1.5",
+        "rollup": "^3.29.5",
+        "url": "^0.11.0",
+        "webpack": "^5.94.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.2.0",
+        "webpack-node-externals": "^3.0.0",
+        "whatwg-fetch": "^3.6.2"
     },
     "dependencies": {
-      "jquery": "^3.7.0",
-      "prop-types": "^15.8.1",
-      "react": "^16.14.0",
-      "react-dom": "^16.14.0"
+        "jquery": "^3.7.0",
+        "prop-types": "^15.8.1",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0"
     }
-  }
-  
+}


### PR DESCRIPTION
**LTSMPS-606 Fixing NPM Organization Name.**

---

**JIRA Ticket**: [LTSMPS-606](https://at-harvard.atlassian.net/browse/LTSMPS-606)

# What does this Pull Request do?

This updates the organization name in the package.json and package-lock.json files to `@harvard-lts` so it can be built and deployed to the correct place in NPM.

[LTSMPS-606]: https://at-harvard.atlassian.net/browse/LTSMPS-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ