### PR TITLE
LTSMPS-631 Fix Related Links

### DIFF
--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -8,6 +8,21 @@ document.addEventListener("DOMContentLoaded", () => {
       {
         manifestId: "https://nrs.lib.harvard.edu/URN-3:FHCL:37563741:MANIFEST:3",
       },
+      {
+        manifestId: "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json",
+      },
+      {
+        manifestId: "https://api.dc.library.northwestern.edu/api/v2/works/1bc233eb-4bb5-4439-9456-d567aaf7977b?as=iiif",
+      }, 
+      {
+        manifestId: "https://media.getty.edu/iiif/manifest/fb9efb54-09dd-42bb-837c-2d27f797cfb2",
+      },
+      {
+        manifestId: "https://nrs.lib.harvard.edu/URN-3:HUL.GUEST:101907912:MANIFEST:3",
+      },
+      {
+        manifestId: "https://nrs.lib.harvard.edu/URN-3:HLS.LIBR:102621314:MANIFEST:3",
+      },
     ],
     miradorCitationPlugin: {
       citationAPI:'YOUR CITATION API ENDPOINT GOES HERE',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-lts/mirador-citation-plugin",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-lts/mirador-citation-plugin",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "react-component"
     ],
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "A Mirador 3 plugin for displaying Harvard-specific citations.",
     "module": "dist/es/index.js",
     "files": [

--- a/src/components/CitationListItem.jsx
+++ b/src/components/CitationListItem.jsx
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Link from '@material-ui/core/Link';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import isValidUrl from '../lib/isValidUrl';
+
+export function CitationListItem({
+    primary, 
+    secondary,
+    i,
+  }) {
+
+    if (isValidUrl(secondary)) {
+        return (
+          <ListItem button component={Link} href={secondary} target="_blank" rel="noopener" key={i}>
+            <ListItemText primary={primary} secondary={secondary}/>
+          </ListItem>
+        );
+    }
+    else {
+        return (
+        <ListItem>
+            <ListItemText primary={primary} secondary={secondary} key={i}/>
+        </ListItem>
+        );
+    }
+}
+  
+CitationListItem.propTypes = {
+    primary: PropTypes.string,
+    secondary: PropTypes.string,
+    i: PropTypes.number,
+};

--- a/src/components/CitationListItem.jsx
+++ b/src/components/CitationListItem.jsx
@@ -10,7 +10,7 @@ export function CitationListItem({
     secondary,
     i,
   }) {
-
+  if (primary !== undefined && secondary !== undefined) {
     if (isValidUrl(secondary)) {
         return (
           <ListItem button component={Link} href={secondary} target="_blank" rel="noopener" key={i}>
@@ -25,6 +25,10 @@ export function CitationListItem({
         </ListItem>
         );
     }
+  }
+  else {
+    return null;
+  }
 }
   
 CitationListItem.propTypes = {

--- a/src/components/CitationSection.jsx
+++ b/src/components/CitationSection.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import CollapsibleSection from 'mirador/dist/es/src/containers/CollapsibleSection';
+import List from '@material-ui/core/List';
+import { CitationListItem } from './CitationListItem';
+
+export function CitationSection({
+    id,
+    label,
+    links, 
+  }) {
+    if (!links) {
+        return null;
+    }
+    else if (links.length === 0) {    
+        return null;
+    }
+    else {
+        return (
+            <CollapsibleSection
+                id={`${id}-${id}`}
+                label={`${label}`}
+            >
+                <List>
+                    {
+                    links.map((link, i) =>
+                        <CitationListItem primary={link.label} secondary={link.link} key={i} />
+                    )
+                    }
+                </List>
+            </CollapsibleSection>        
+        );
+    }
+
+}
+    
+CitationSection.propTypes = {
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    links: PropTypes.arrayOf(PropTypes.object),
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,20 @@ import CitationPanel from './plugins/citations/panel/plugin';
 import CitationButton from './plugins/citations/button/plugin';
 import RelatedLinksPanel from './plugins/related-links/panel/plugin';
 import RelatedLinksButton from './plugins/related-links/button/plugin';
+import WindowSidebarButtons from './plugins/windowSidebarButtons/plugin';
 
 export { 
     CitationPanel,
     CitationButton,
     RelatedLinksPanel,
-    RelatedLinksButton
+    RelatedLinksButton,
+    WindowSidebarButtons
 };
 
 export default [
     CitationPanel,
     CitationButton,
     RelatedLinksPanel,
-    RelatedLinksButton
+    RelatedLinksButton,
+    WindowSidebarButtons
 ];

--- a/src/lib/isValidUrl.js
+++ b/src/lib/isValidUrl.js
@@ -1,0 +1,10 @@
+/**
+ */
+export default function isValidUrl(url) {
+    try {
+        new URL(url);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}

--- a/src/plugins/citations/button/plugin.js
+++ b/src/plugins/citations/button/plugin.js
@@ -1,13 +1,59 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
 import CitationIcon from "@material-ui/icons/FormatQuote";
+import { getManifestTitle, getManifestUrl } from 'mirador/dist/es/src/state/selectors';
 
-const CitationButton = () => (
-  <CitationIcon />
-);
+class CitationButton extends Component {
+  constructor(props) {
+    super(props);
+    const { manifestId, citationAPI, manifestTitle } = this.props;
+    console.log('manifestId2:' + manifestId);
+    this.state = {
+      manifestId: manifestId,
+      citationAPI: citationAPI,
+      manifestTitle: manifestTitle,
+    };
+  }
+  async componentDidMount() {
+    const { manifestId, citationAPI, manifestTitle } = this.state;
+    console.log('manifestId:', manifestId);
+  }
+  render() {
+    return (
+      <CitationIcon />
+    );
+  }
+
+}
+
 CitationButton.value = 'CitationKey';
+
+const mapStateToProps = (state, { windowId }) => ({
+  manifestId: getManifestUrl(state, { windowId }),
+  citationAPI: state.config.miradorCitationPlugin?.citationAPI,
+  manifestTitle: getManifestTitle(state, { windowId }),
+});
+
+const enhance = compose(
+  connect(mapStateToProps),
+);
+
+CitationButton.propTypes = {
+  manifestId: PropTypes.string,
+  citationAPI: PropTypes.string,
+  manifestTitle: PropTypes.string,
+};
+
+CitationButton.defaultProps = {
+  manifestId: null,
+  citationAPI: null,
+  manifestTitle: null,
+};
 
 export default {
   target: 'WindowSideBarButtons',
   mode: 'add',
-  component: CitationButton
+  component: enhance(CitationButton)
 };

--- a/src/plugins/citations/button/plugin.js
+++ b/src/plugins/citations/button/plugin.js
@@ -3,13 +3,20 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import CitationIcon from "@material-ui/icons/FormatQuote";
+import Icon from "@material-ui/core/Icon";
 import { getManifestTitle, getManifestUrl } from 'mirador/dist/es/src/state/selectors';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = theme => ({
+  hideCitationButton: {
+    display: 'none',
+  },
+});
 
 class CitationButton extends Component {
   constructor(props) {
     super(props);
     const { manifestId, citationAPI, manifestTitle } = this.props;
-    console.log('manifestId2:' + manifestId);
     this.state = {
       manifestId: manifestId,
       citationAPI: citationAPI,
@@ -18,35 +25,97 @@ class CitationButton extends Component {
   }
   async componentDidMount() {
     const { manifestId, citationAPI, manifestTitle } = this.state;
-    console.log('manifestId:', manifestId);
+    const body = { "manifest_id": manifestId };
+    fetch(citationAPI, {
+      method: 'post',
+      body: JSON.stringify(body),
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then(response => {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(citationData => {
+        this.setState({ citationData, loading: false });
+      })
+      .catch(error => {
+        console.error('There was a problem receiving the citation:', error);
+        this.setState({ loading: false, error: error.message });
+    });
   }
   render() {
-    return (
-      <CitationIcon />
-    );
+    const { classes, 
+      windowId,
+     } = this.props;
+    const { citationData, loading, error } = this.state;
+    if (citationData) {
+      if (!citationData.error) {
+        return (
+          <div>
+            <CitationIcon />
+          </div>
+        );
+      }
+      else {
+        return (
+          <div className={classes.hideCitationButton}>
+            <style>
+              {`
+              section[id="`+windowId+`"] button[title="Cite"] { display: none }
+              `}
+            </style>
+            <Icon />
+          </div>
+        );
+      }
+    }
+    else {
+      return (
+        <div className={classes.hideCitationButton}>
+            <style>
+              {`
+              section[id="`+windowId+`"] button[title="Cite"] { display: none }
+              `}
+            </style>
+          <Icon />
+        </div>
+      );
+    }
   }
 
 }
 
 CitationButton.value = 'CitationKey';
 
-const mapStateToProps = (state, { windowId }) => ({
-  manifestId: getManifestUrl(state, { windowId }),
-  citationAPI: state.config.miradorCitationPlugin?.citationAPI,
-  manifestTitle: getManifestTitle(state, { windowId }),
-});
+const mapStateToProps = (state, { windowId }) => {
+
+  const manifestId = getManifestUrl(state, { windowId });
+  const citationAPI = state.config.miradorCitationPlugin?.citationAPI;
+  const manifestTitle = getManifestTitle(state, { windowId });
+
+  return {
+    manifestId: manifestId,
+    citationAPI: citationAPI,
+    manifestTitle: manifestTitle,
+  };
+};
 
 const enhance = compose(
+  withStyles(styles),
   connect(mapStateToProps),
 );
 
 CitationButton.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string),
   manifestId: PropTypes.string,
   citationAPI: PropTypes.string,
   manifestTitle: PropTypes.string,
 };
 
 CitationButton.defaultProps = {
+  classes: {},
   manifestId: null,
   citationAPI: null,
   manifestTitle: null,
@@ -54,6 +123,7 @@ CitationButton.defaultProps = {
 
 export default {
   target: 'WindowSideBarButtons',
+  name: 'WindowSideBarCitationButton',
   mode: 'add',
   component: enhance(CitationButton)
 };

--- a/src/plugins/citations/panel/component.js
+++ b/src/plugins/citations/panel/component.js
@@ -6,9 +6,8 @@ import SanitizedHtml from 'mirador/dist/es/src/containers/SanitizedHtml';
 import { PluginHook } from 'mirador/dist/es/src/components/PluginHook';
 import ns from 'mirador/dist/es/src/config/css-ns';
 import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
+import { CitationListItem } from '../../../components/CitationListItem';
 
 export default class CitationSidePanel extends Component {
   constructor(props) {
@@ -85,36 +84,11 @@ export default class CitationSidePanel extends Component {
                   label={'resource'}
                 >
                   <List>
-                      <ListItem>
-                      <ListItemText
-                        primary="Persistent Link:"
-                        secondary={citationData.resource_persistent_link}
-                      />
-                      </ListItem>
-                      <ListItem>
-                      <ListItemText
-                        primary="Description:"
-                        secondary={manifestTitle}
-                      />
-                      </ListItem>
-                      <ListItem>
-                      <ListItemText
-                        primary="Repository:"
-                        secondary={citationData.repository}
-                      />
-                      </ListItem>
-                      <ListItem>
-                      <ListItemText
-                        primary="Institution:"
-                        secondary={citationData.institution}
-                      />
-                      </ListItem>
-                      <ListItem>
-                      <ListItemText
-                        primary="Accessed:"
-                        secondary={citationData.access_date}
-                      />
-                      </ListItem>
+                      <CitationListItem primary="Persistent Link:" secondary={citationData.resource_persistent_link}/>
+                      <CitationListItem primary="Description:" secondary={manifestTitle}/>
+                      <CitationListItem primary="Repository:" secondary={citationData.repository}/>
+                      <CitationListItem primary="Institution:" secondary={citationData.institution}/>
+                      <CitationListItem primary="Accessed:" secondary={citationData.access_date}/>
                   </List>
                 </CollapsibleSection>
               </div>

--- a/src/plugins/citations/panel/plugin.js
+++ b/src/plugins/citations/panel/plugin.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import CitationSidePanel from './component';
 import { withStyles } from '@material-ui/core/styles';
 import { withTranslation } from 'react-i18next';
-import { getManifestTitle } from 'mirador/dist/es/src/state/selectors';
+import { getManifestTitle, getManifestUrl } from 'mirador/dist/es/src/state/selectors';
 
 const styles = theme => ({
   section: {
@@ -22,7 +22,7 @@ const styles = theme => ({
 });
 
 const mapStateToProps = (state, { id, windowId }) => ({
-  manifestId: state.config.windows[0]?.manifestId,
+  manifestId: getManifestUrl(state, { windowId }),
   citationAPI: state.config.miradorCitationPlugin?.citationAPI,
   manifestTitle: getManifestTitle(state, { windowId }),
 });

--- a/src/plugins/related-links/button/plugin.js
+++ b/src/plugins/related-links/button/plugin.js
@@ -1,13 +1,129 @@
-import React from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
 import RelatedLinksIcon from '@material-ui/icons/Link';
+import Icon from "@material-ui/core/Icon";
+import { getManifestTitle, getManifestUrl } from 'mirador/dist/es/src/state/selectors';
+import { withStyles } from '@material-ui/core/styles';
 
-const RelatedLinksButton = () => (
-  <RelatedLinksIcon />
-);
+const styles = theme => ({
+  hideRelatedLinksButton: {
+    display: 'none',
+  },
+});
+
+class RelatedLinksButton extends Component {
+  constructor(props) {
+    super(props);
+    const { manifestId, citationAPI, manifestTitle } = this.props;
+    this.state = {
+      manifestId: manifestId,
+      citationAPI: citationAPI,
+      manifestTitle: manifestTitle,
+    };
+  }
+  async componentDidMount() {
+    const { manifestId, citationAPI, manifestTitle } = this.state;
+    const body = { "manifest_id": manifestId };
+    fetch(citationAPI, {
+      method: 'post',
+      body: JSON.stringify(body),
+      headers: {'Content-Type': 'application/json'}
+    })
+      .then(response => {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        return response.json();
+      })
+      .then(citationData => {
+        this.setState({ citationData, loading: false });
+      })
+      .catch(error => {
+        console.error('There was a problem receiving the citation:', error);
+        this.setState({ loading: false, error: error.message });
+    });
+  }
+  render() {
+    const { classes, 
+      windowId,
+     } = this.props;
+    const { citationData, loading, error } = this.state;
+    if (citationData) {
+      if (!citationData.error) {
+        return (
+          <div>
+            <RelatedLinksIcon />
+          </div>
+        );
+      }
+      else {
+        return (
+          <div className={classes.hideRelatedLinksButton}>
+            <style>
+              {`
+              section[id="`+windowId+`"] button[title="Related Links"] { display: none }
+              `}
+            </style>
+            <Icon />
+          </div>
+        );
+      }
+    }
+    else {
+      return (
+        <div className={classes.hideRelatedLinksButton}>
+            <style>
+              {`
+              section[id="`+windowId+`"] button[title="Related Links"] { display: none }
+              `}
+            </style>
+          <Icon />
+        </div>
+      );
+    }
+  }
+
+}
+
 RelatedLinksButton.value = 'RelatedLinksKey';
+
+const mapStateToProps = (state, { windowId }) => {
+
+  const manifestId = getManifestUrl(state, { windowId });
+  const citationAPI = state.config.miradorCitationPlugin?.citationAPI;
+  const manifestTitle = getManifestTitle(state, { windowId });
+
+  return {
+    manifestId: manifestId,
+    citationAPI: citationAPI,
+    manifestTitle: manifestTitle,
+  };
+};
+
+const enhance = compose(
+  withStyles(styles),
+  connect(mapStateToProps),
+);
+
+RelatedLinksButton.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.string),
+  manifestId: PropTypes.string,
+  citationAPI: PropTypes.string,
+  manifestTitle: PropTypes.string,
+};
+
+RelatedLinksButton.defaultProps = {
+  classes: {},
+  manifestId: null,
+  citationAPI: null,
+  manifestTitle: null,
+};
 
 export default {
   target: 'WindowSideBarButtons',
+  name: 'WindowSideBarRelatedLinksButton',
   mode: 'add',
-  component: RelatedLinksButton
+  component: enhance(RelatedLinksButton)
 };

--- a/src/plugins/related-links/panel/component.js
+++ b/src/plugins/related-links/panel/component.js
@@ -1,15 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import CompanionWindow from 'mirador/dist/es/src/containers/CompanionWindow';
-import CollapsibleSection from 'mirador/dist/es/src/containers/CollapsibleSection';
 import SanitizedHtml from 'mirador/dist/es/src/containers/SanitizedHtml';
 import { PluginHook } from 'mirador/dist/es/src/components/PluginHook';
 import ns from 'mirador/dist/es/src/config/css-ns';
-import Link from '@material-ui/core/Link';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
+import { CitationSection } from '../../../components/CitationSection';
 export default class RelatedLinksSidePanel extends Component {
   constructor(props) {
     super(props);
@@ -83,43 +79,11 @@ export default class RelatedLinksSidePanel extends Component {
             {loading && <p>Loading...</p>}
             {error && <p>Error: {error}</p>}
           </Typography>
-
+            
             {citationData &&
               <div className={classes.section}>
-                <CollapsibleSection
-                  id={`${id}-harvard-metadata`}
-                  label={'harvard metadata'}
-                >
-                  <List>
-                    {
-                        citationData.harvard_metadata_links.map((metadataLink, i) =>
-                            <ListItem button component={Link} href={metadataLink.link} target="_blank" rel="noopener" key={i}>
-                            <ListItemText
-                            primary={metadataLink.label}
-                            secondary={metadataLink.link}
-                            />
-                            </ListItem>
-                        )
-                    }
-                  </List>
-                </CollapsibleSection>
-                <CollapsibleSection
-                  id={`${id}-related-links`}
-                  label={'related links'}
-                >
-                  <List>
-                  {
-                        citationData.related_links.map((relatedLink, i) =>
-                            <ListItem button component={Link} href={relatedLink.link} target="_blank" rel="noopener" key={i}>
-                            <ListItemText
-                            primary={relatedLink.label}
-                            secondary={relatedLink.link}
-                            />
-                            </ListItem>
-                        )
-                    }
-                  </List>
-                </CollapsibleSection>
+                <CitationSection id='harvard-metadata' label='harvard metadata' links={citationData.harvard_metadata_links}/>
+                <CitationSection id='related-links' label='related links' links={citationData.related_links}/>
               </div>
             }
             <PluginHook {...this.props} />

--- a/src/plugins/related-links/panel/plugin.js
+++ b/src/plugins/related-links/panel/plugin.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import RelatedLinksSidePanel from './component';
 import { withStyles } from '@material-ui/core/styles';
 import { withTranslation } from 'react-i18next';
-import { getManifestTitle } from 'mirador/dist/es/src/state/selectors';
+import { getManifestTitle, getManifestUrl  } from 'mirador/dist/es/src/state/selectors';
 
 const styles = theme => ({
   section: {
@@ -22,7 +22,7 @@ const styles = theme => ({
 });
 
 const mapStateToProps = (state, { id, windowId }) => ({
-  manifestId: state.config.windows[0]?.manifestId,
+  manifestId: getManifestUrl(state, { windowId }),
   citationAPI: state.config.miradorCitationPlugin?.citationAPI,
   manifestTitle: getManifestTitle(state, { windowId }),
 });

--- a/src/plugins/windowSidebarButtons/component.js
+++ b/src/plugins/windowSidebarButtons/component.js
@@ -1,0 +1,169 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Badge from '@material-ui/core/Badge';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Tooltip from '@material-ui/core/Tooltip';
+import InfoIcon from '@material-ui/icons/InfoSharp';
+import AnnotationIcon from '@material-ui/icons/CommentSharp';
+import AttributionIcon from '@material-ui/icons/CopyrightSharp';
+import LayersIcon from '@material-ui/icons/LayersSharp';
+import SearchIcon from '@material-ui/icons/SearchSharp';
+import CanvasIndexIcon from 'mirador/dist/es/src/components/icons/CanvasIndexIcon';
+/**
+ *
+ */
+export class WindowSideBarButtons extends Component {
+  /** */
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  /**
+   * @param {object} event the change event
+   * @param {string} value the tab's value
+  */
+  handleChange(event, value) {
+    const { addCompanionWindow } = this.props;
+
+    addCompanionWindow(value);
+  }
+
+  /**
+   * render
+   *
+   * @return {type}  description
+   */
+  render() {
+    const {
+      classes,
+      hasAnnotations,
+      hasAnyAnnotations,
+      hasAnyLayers,
+      hasCurrentLayers,
+      hasSearchResults,
+      hasSearchService,
+      panels,
+      PluginComponents,
+      sideBarPanel,
+      t,
+      windowId,
+    } = this.props;
+
+    /** */
+    const TabButton = props => (
+      <Tooltip title={t('openCompanionWindow', { context: props.value })}>
+        <Tab
+          {...props}
+          classes={{ root: classes.tab, selected: classes.tabSelected }}
+          aria-label={
+            t('openCompanionWindow', { context: props.value })
+          }
+          disableRipple
+          onKeyUp={this.handleKeyUp}
+        />
+      </Tooltip>
+    );
+
+    return (
+      <Tabs
+        classes={{ flexContainer: classes.tabsFlexContainer, indicator: classes.tabsIndicator }}
+        value={sideBarPanel === 'closed' ? false : sideBarPanel}
+        onChange={this.handleChange}
+        variant="fullWidth"
+        indicatorColor="primary"
+        textColor="primary"
+        orientation="vertical"
+        aria-orientation="vertical"
+        aria-label={t('sidebarPanelsNavigation')}
+      >
+        { panels.info && (
+          <TabButton
+            value="info"
+            icon={(<InfoIcon />)}
+          />
+        )}
+        { panels.attribution && (
+          <TabButton
+            value="attribution"
+            icon={(<AttributionIcon />)}
+          />
+        )}
+        { panels.canvas && (
+          <TabButton
+            value="canvas"
+            icon={(<CanvasIndexIcon />)}
+          />
+        )}
+        {panels.annotations && (hasAnnotations || hasAnyAnnotations) && (
+          <TabButton
+            value="annotations"
+            icon={(
+              <Badge classes={{ badge: classes.badge }} invisible={!hasAnnotations} variant="dot">
+                <AnnotationIcon />
+              </Badge>
+            )}
+          />
+        )}
+        {panels.search && hasSearchService && (
+          <TabButton
+            value="search"
+            icon={(
+              <Badge classes={{ badge: classes.badge }} invisible={!hasSearchResults} variant="dot">
+                <SearchIcon />
+              </Badge>
+            )}
+          />
+        )}
+        { panels.layers && hasAnyLayers && (
+          <TabButton
+            value="layers"
+            icon={(
+              <Badge classes={{ badge: classes.badge }} invisible={!hasCurrentLayers} variant="dot">
+                <LayersIcon />
+              </Badge>
+            )}
+          />
+        )}
+        { PluginComponents
+          && PluginComponents.map(PluginComponent => (
+            <TabButton
+              key={PluginComponent.value}
+              value={PluginComponent.value}
+              icon={<PluginComponent windowId={windowId} />}
+            />
+          ))}
+      </Tabs>
+    );
+  }
+}
+
+WindowSideBarButtons.propTypes = {
+  addCompanionWindow: PropTypes.func.isRequired,
+  classes: PropTypes.objectOf(PropTypes.string),
+  hasAnnotations: PropTypes.bool,
+  hasAnyAnnotations: PropTypes.bool,
+  hasAnyLayers: PropTypes.bool,
+  hasCurrentLayers: PropTypes.bool,
+  hasSearchResults: PropTypes.bool,
+  hasSearchService: PropTypes.bool,
+  panels: PropTypes.arrayOf(PropTypes.bool),
+  PluginComponents: PropTypes.array, // eslint-disable-line react/forbid-prop-types
+  sideBarPanel: PropTypes.string,
+  t: PropTypes.func,
+};
+
+WindowSideBarButtons.defaultProps = {
+  classes: {},
+  hasAnnotations: false,
+  hasAnyAnnotations: false,
+  hasAnyLayers: false,
+  hasCurrentLayers: false,
+  hasSearchResults: false,
+  hasSearchService: false,
+  panels: [],
+  PluginComponents: null,
+  sideBarPanel: 'closed',
+  t: key => key,
+};

--- a/src/plugins/windowSidebarButtons/plugin.js
+++ b/src/plugins/windowSidebarButtons/plugin.js
@@ -1,0 +1,118 @@
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withStyles } from '@material-ui/core';
+import { withTranslation } from 'react-i18next';
+import { withPlugins } from 'mirador/dist/es/src/extend/withPlugins';
+import * as actions from 'mirador/dist/es/src/state/actions';
+import MiradorCanvas from 'mirador/dist/es/src/lib/MiradorCanvas';
+import {
+  getCanvases,
+  getVisibleCanvases,
+  getCompanionWindowsForPosition,
+  getAnnotationResourcesByMotivation,
+  getManifestSearchService,
+  getSearchQuery,
+  getWindow,
+  getWindowConfig,
+} from 'mirador/dist/es/src/state/selectors';
+import { WindowSideBarButtons } from './component';
+
+/**
+ * mapDispatchToProps - used to hook up connect to action creators
+ * @memberof WindowSideButtons
+ * @private
+ */
+const mapDispatchToProps = (dispatch, { windowId }) => ({
+  addCompanionWindow: content => dispatch(
+    actions.addOrUpdateCompanionWindow(windowId, { content, position: 'left' }),
+  ),
+});
+
+/** */
+function hasLayers(canvases) {
+  return canvases && canvases.some(c => new MiradorCanvas(c).imageResources.length > 1);
+}
+
+/** */
+function hasAnnotations(canvases) {
+  return canvases && canvases.some(c => {
+    const canvas = new MiradorCanvas(c);
+
+    return canvas.annotationListUris.length > 0
+      || canvas.canvasAnnotationPages.length > 0;
+  });
+}
+
+/**
+ * mapStateToProps - used to hook up connect to state
+ * @memberof WindowSideButtons
+ * @private
+ */
+const mapStateToProps = (state, { windowId }) => ({
+  hasAnnotations: getAnnotationResourcesByMotivation(
+    state,
+    { windowId },
+  ).length > 0,
+  hasAnyAnnotations: hasAnnotations(getCanvases(state, { windowId })),
+  hasAnyLayers: hasLayers(getCanvases(state, { windowId })),
+  hasCurrentLayers: hasLayers(getVisibleCanvases(state, { windowId })),
+  hasSearchResults: getWindow(state, { windowId }).suggestedSearches || getSearchQuery(state, {
+    companionWindowId: (getCompanionWindowsForPosition(state, { position: 'left', windowId })[0] || {}).id,
+    windowId,
+  }),
+  hasSearchService: getManifestSearchService(state, { windowId }) !== null,
+  panels: getWindowConfig(state, { windowId }).panels,
+  sideBarPanel: ((getCompanionWindowsForPosition(state, { position: 'left', windowId }))[0] || {}).content,
+});
+
+/** */
+const style = theme => ({
+  badge: {
+    backgroundColor: theme.palette.notification.main,
+  },
+  tab: {
+    '&:active': {
+      backgroundColor: theme.palette.action.active,
+    },
+    '&:focus': {
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+      backgroundColor: theme.palette.action.hover,
+      textDecoration: 'none',
+      // Reset on touch devices, it doesn't add specificity
+    },
+    '&:hover': {
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+      backgroundColor: theme.palette.action.hover,
+      textDecoration: 'none',
+      // Reset on touch devices, it doesn't add specificity
+    },
+
+    borderRight: '2px solid transparent',
+    minWidth: 'auto',
+  },
+  tabSelected: {
+    borderRight: `2px solid ${theme.palette.primary.main}`,
+  },
+  tabsFlexContainer: {
+    flexDirection: 'column',
+  },
+  tabsIndicator: {
+    display: 'none',
+  },
+});
+
+const enhance = compose(
+  withTranslation(),
+  withStyles(style),
+  connect(mapStateToProps, mapDispatchToProps),
+);
+
+export default {
+  target: 'WindowSideBarButtons',
+  mode: 'wrap',
+  component: enhance(WindowSideBarButtons)
+};


### PR DESCRIPTION
**LTSMPS-631 Fix Related Links**

---

**JIRA Tickets**: 

- [LTSMPS-631](https://at-harvard.atlassian.net/browse/LTSMPS-631)
- [LTSVIEWER-323](https://at-harvard.atlassian.net/browse/LTSVIEWER-323)

# What does this Pull Request do?

This fixes a few things with the Mirador Citation Plugin:

- It displays the proper citations and related links for the objects if there are multiple objects in the viewer simultanously
- It does not display subsections of Citations or Related Links if they are empty
- If related links are empty, it does not throw an error in the Viewer
- If it is a non-Harvard object (or nothing is returned from the Citation API) then the Cite and Related Links icons are not displayed.

# How should this be tested?

A description of what steps someone could take to:

- Pull in the code from the `LTSMPS-631-fix-related-links` branch
- Add the production Citation API endpoint to `citationAPI` in `demo/demoEntry.js`
- Run `npm run serve`
- A Mirador Viewer with 6 objects displayed will automatically load in your browser.
- Open up the hamburger menu to test the Citations and Related Links.
- "Ross, Ronald Sir 1857-1932. Mosquito brigades..." object should display Citations and Related Links. There are several related links (Gale, HLSL, HULPR etc) that are not actually links and should not be clickable
- "Cecil F. Poole Papers..." object should display Citations and Related Links. The Related Links section should only have the "Harvard Metadata" subsection
- "Ryūtei, Tanehiko 1783-1842..." object should display Citations and Related Links. the Related Links section should have both "Harvard Metadata" and "Related Links" subsections.
- "Letters to Mrs. Aldridge" (Northwestern), "Folio from Grandes Chroniques de France" (iiif.io), and "The Monument. [London, England]" (Getty Images) should not display the Cite and Related Links icons. 


# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@enriquediaz @f8f8ff 


[LTSMPS-631]: https://at-harvard.atlassian.net/browse/LTSMPS-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LTSVIEWER-323]: https://at-harvard.atlassian.net/browse/LTSVIEWER-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ