### PR TITLE
LTSVIEWER-362 Fix Icons

### DIFF
--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", () => {
         xsideBarPanel: 'info',
       },
       {
-        manifestId: "https://mps.lib.harvard.edu/iiif/3/urn-3:HUAM:93_122_36a",
+        manifestId: "https://nrs.harvard.edu/URN-3:HUAM:93_122_36A:MANIFEST:3",
         sideBarOpen: true,
         xsideBarPanel: 'info',
       },

--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -7,21 +7,38 @@ document.addEventListener("DOMContentLoaded", () => {
     windows: [
       {
         manifestId: "https://nrs.lib.harvard.edu/URN-3:FHCL:37563741:MANIFEST:3",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
       },
       {
         manifestId: "https://iiif.io/api/cookbook/recipe/0036-composition-from-multiple-images/manifest.json",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
       },
       {
         manifestId: "https://api.dc.library.northwestern.edu/api/v2/works/1bc233eb-4bb5-4439-9456-d567aaf7977b?as=iiif",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
       }, 
       {
         manifestId: "https://media.getty.edu/iiif/manifest/fb9efb54-09dd-42bb-837c-2d27f797cfb2",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
       },
       {
         manifestId: "https://nrs.lib.harvard.edu/URN-3:HUL.GUEST:101907912:MANIFEST:3",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
       },
       {
         manifestId: "https://nrs.lib.harvard.edu/URN-3:HLS.LIBR:102621314:MANIFEST:3",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
+      },
+      {
+        manifestId: "https://mps.lib.harvard.edu/iiif/3/urn-3:HUAM:93_122_36a",
+        sideBarOpen: true,
+        xsideBarPanel: 'info',
       },
     ],
     miradorCitationPlugin: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-lts/mirador-citation-plugin",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-lts/mirador-citation-plugin",
-            "version": "0.0.4",
+            "version": "0.0.5",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "react-component"
     ],
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "A Mirador 3 plugin for displaying Harvard-specific citations.",
     "module": "dist/es/index.js",
     "files": [

--- a/src/plugins/citations/button/plugin.js
+++ b/src/plugins/citations/button/plugin.js
@@ -21,29 +21,63 @@ class CitationButton extends Component {
       manifestId: manifestId,
       citationAPI: citationAPI,
       manifestTitle: manifestTitle,
+      citationData: null,
+      loading: true,
+      error: null,
     };
   }
   async componentDidMount() {
     const { manifestId, citationAPI, manifestTitle } = this.state;
+    
+    // Only fetch if we have the required data
+    if (manifestId && citationAPI) {
+      this.fetchCitationData(manifestId, citationAPI);
+    } else {
+      console.log('CitationButton: manifestId or citationAPI not available yet', { manifestId, citationAPI });
+    }
+  }
+
+  async componentDidUpdate(prevProps, prevState) {
+    // Check if props changed and update state accordingly
+    const { manifestId: newManifestId, citationAPI: newCitationAPI, manifestTitle: newManifestTitle } = this.props;
+    const { manifestId: prevManifestId, citationAPI: prevCitationAPI } = prevState;
+    
+    // Update state if props changed
+    if (newManifestId !== prevManifestId || newCitationAPI !== prevCitationAPI || newManifestTitle !== prevState.manifestTitle) {
+      this.setState({
+        manifestId: newManifestId,
+        citationAPI: newCitationAPI,
+        manifestTitle: newManifestTitle,
+      });
+    }
+    
+    // Check if manifestId or citationAPI became available and fetch data
+    const { manifestId, citationAPI } = this.state;
+    if ((manifestId !== prevManifestId || citationAPI !== prevCitationAPI) && manifestId && citationAPI) {
+      this.fetchCitationData(manifestId, citationAPI);
+    }
+  }
+
+  fetchCitationData = async (manifestId, citationAPI) => {
     const body = { "manifest_id": manifestId };
-    fetch(citationAPI, {
-      method: 'post',
-      body: JSON.stringify(body),
-      headers: {'Content-Type': 'application/json'}
-    })
-      .then(response => {
-        if (!response.ok) {
-            throw new Error('Network response was not ok');
-        }
-        return response.json();
-      })
-      .then(citationData => {
-        this.setState({ citationData, loading: false });
-      })
-      .catch(error => {
-        console.error('There was a problem receiving the citation:', error);
-        this.setState({ loading: false, error: error.message });
-    });
+    
+    try {
+      const response = await fetch(citationAPI, {
+        method: 'post',
+        body: JSON.stringify(body),
+        headers: {'Content-Type': 'application/json'}
+      });
+      
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      
+      const citationData = await response.json();
+      this.setState({ citationData, loading: false });
+    } catch (error) {
+      console.error('There was a problem receiving the citation:', error);
+      this.setState({ loading: false, error: error.message });
+    }
   }
   render() {
     const { classes, 

--- a/src/plugins/related-links/button/plugin.js
+++ b/src/plugins/related-links/button/plugin.js
@@ -124,15 +124,9 @@ class RelatedLinksButton extends Component {
 RelatedLinksButton.value = 'RelatedLinksKey';
 
 const mapStateToProps = (state, { windowId }) => {
-  console.log('RelatedLinksButton mapStateToProps windowId=', windowId);
-  console.log('RelatedLinksButton mapStateToProps state=', state);
-
   const manifestId = getManifestUrl(state, { windowId });
   const citationAPI = state.config.miradorCitationPlugin?.citationAPI;
   const manifestTitle = getManifestTitle(state, { windowId });
-
-  console.log('RelatedLinksButton mapStateToProps extracted values:', { manifestId, citationAPI, manifestTitle });
-
   return {
     manifestId: manifestId,
     citationAPI: citationAPI,


### PR DESCRIPTION
**LTSVIEWER-362 Fix Icons.**

---

**JIRA Ticket**: [LTSVIEWER-362](https://at-harvard.atlassian.net/browse/LTSVIEWER-362)

# What does this Pull Request do?

This fixes the Citation and Related Links icons that appear in the info panel. Since the info panel is open by default, they did not display until you interacted with the page (changing panels for example). The icons now appear on page load.

A brief description of what the intended result of the PR will be and/or what problem it solves.

# How should this be tested?

- Pull in the code from the `LTSVIEWER-362-fix-icons` branch
- In demo/demoEntry.js Add the production Citation API endpoint to line 45 (You can find this in the VIEWER-INFRA project)
- In a command prompt run `npm run serve` This will open the plugin in a new browser window at http://localhost:9000
- the icons should appear automatically for the following items: `Archaelogical Exploration of Sardis, 93_122_36a`, `Ryūtei, Tanehiko 1783-1842.` and `Cecil F. Poole Papers, 1939-1997.`. They do not display for the others as they do not have citations or related links delivered by the Harvard Citations API (They are from other institutions).

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@enriquediaz 


[LTSVIEWER-362]: https://at-harvard.atlassian.net/browse/LTSVIEWER-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ