### PR TITLE
LTSVIEWER-372 Update NPM token

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Publish to npm
         run: npm publish --access=public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.LTS_NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-lts/mirador-citation-plugin",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-lts/mirador-citation-plugin",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "react-component"
     ],
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "A Mirador 3 plugin for displaying Harvard-specific citations.",
     "module": "dist/es/index.js",
     "files": [


### PR DESCRIPTION
**LTSVIEWER-372 Update NPM token**

---

**JIRA Ticket**: [LTSVIEWER-372](https://at-harvard.atlassian.net/browse/LTSVIEWER-372)

# What does this Pull Request do?
Update the publish GHA to use the new organization secret `LTS_NPM_TOKEN`.

# How should this be tested?
The best way to test it is to merge this PR and create a new release tagged `v0.0.6` and see if it publishes correctly.

[LTSVIEWER-372]: https://at-harvard.atlassian.net/browse/LTSVIEWER-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ